### PR TITLE
Fix blog key naming

### DIFF
--- a/channel_groups.json
+++ b/channel_groups.json
@@ -12,7 +12,7 @@
     "@keddr",
     "@prostirspokoy"
   ],
-  "blogs": [
+  "blog": [
     "@MichaelPatsan",
     "@theworldisnoteasy",
     "@prostirspokoy",


### PR DESCRIPTION
## Summary
- rename `blogs` key to `blog` to match configuration

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6840265987948324b88cf86826126c55