### PR TITLE
Make bot messaging async

### DIFF
--- a/bot/poster.py
+++ b/bot/poster.py
@@ -3,36 +3,27 @@ from aiogram.types import FSInputFile
 from aiogram.exceptions import TelegramBadRequest
 from config import STREAM_IMAGES
 from .bot_instance import bot
-import requests  # type: ignore[import-untyped]
-from config import CHAT_ID, BOT_TOKEN, MAX_RETRIES
+from config import CHAT_ID, MAX_RETRIES
 from shared.logger import logger
-from time import sleep
 from loguru import logger
+import asyncio
 
 async def send_html_message(html: str) -> None:
     for attempt in range(1, MAX_RETRIES + 1):
         try:
             logger.debug(f"📤 HTML до Telegram:\n{html}")
-            response = requests.post(
-                f"https://api.telegram.org/bot{BOT_TOKEN}/sendMessage",
-                data={
-                    "chat_id": CHAT_ID,
-                    "text": html,
-                    "parse_mode": "HTML",
-                    "disable_web_page_preview": True,
-                },
-                timeout=15
+            await bot.send_message(
+                chat_id=str(CHAT_ID),
+                text=html,
+                parse_mode="HTML",
+                disable_web_page_preview=True,
             )
-            resp_json = response.json()
-            if response.status_code == 200 and resp_json.get("ok"):
-                logger.info("✅ Повідомлення успішно надіслано в Telegram.")
-                return
-            else:
-                raise Exception(f"{response.status_code} {response.reason}: {resp_json}")
+            logger.info("✅ Повідомлення успішно надіслано в Telegram.")
+            return
         except Exception as e:
             logger.warning(f"⚠️ [Спроба {attempt}] Помилка надсилання повідомлення: {e}")
             if attempt < MAX_RETRIES:
-                sleep(2 * attempt)
+                await asyncio.sleep(2 * attempt)
             else:
                 logger.error("❌ Повідомлення не надіслано навіть після повторних спроб.")
 


### PR DESCRIPTION
## Summary
- remove requests dependency from `bot/poster.py`
- send HTML messages with aiogram's async `bot.send_message`
- use `asyncio.sleep` for retry delays

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840270274dc8324bfa6c4f94686f68a