### PR TITLE
Fix category name mismatch and cleanup logger import

### DIFF
--- a/bot/poster.py
+++ b/bot/poster.py
@@ -7,7 +7,6 @@ import requests  # type: ignore[import-untyped]
 from config import CHAT_ID, BOT_TOKEN, MAX_RETRIES
 from shared.logger import logger
 from time import sleep
-from loguru import logger
 
 async def send_html_message(html: str) -> None:
     for attempt in range(1, MAX_RETRIES + 1):

--- a/channel_groups.json
+++ b/channel_groups.json
@@ -12,7 +12,7 @@
     "@keddr",
     "@prostirspokoy"
   ],
-  "blogs": [
+  "blog": [
     "@MichaelPatsan",
     "@theworldisnoteasy",
     "@prostirspokoy",


### PR DESCRIPTION
## Summary
- fix category key in `channel_groups.json`
- remove duplicate logger import in `bot/poster.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684023e39e608324acf50140bbb20ab2