### PR TITLE
Fix rate limiting for Groq API

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,7 +13,8 @@ GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 
 # === Settings ===
 DEFAULT_MODEL = "llama3-70b-8192"
-FALLBACK_MODEL = "mixtral-8x22b"
+FALLBACK_MODEL = "mixtral-8x7b-32768"
+RATE_LIMIT_INTERVAL = 0.7  # seconds between LLM requests
 MAX_RETRIES = 3
 MAX_NEW_POSTS_PER_CHANNEL = 5
 


### PR DESCRIPTION
## Summary
- add rate limit interval and valid fallback model
- throttle Groq API calls to stay under rate limits

## Testing
- `python3 -m mypy .`

------
https://chatgpt.com/codex/tasks/task_e_68402bd0f6148324b5cead9cb9c37c59