### PR TITLE
Add TELEGRAM_MESSAGE_LIMIT constant

### DIFF
--- a/bot/formatter.py
+++ b/bot/formatter.py
@@ -1,4 +1,4 @@
-from config import POST_ENTRY_EMOJI
+from config import POST_ENTRY_EMOJI, TELEGRAM_MESSAGE_LIMIT
 from shared.custom_types import TelegramPost, SummaryEntry
 from summarizer.summarizer import summarize_text
 from shared.logger import logger
@@ -34,7 +34,7 @@ async def format_digest(category: str, posts: list[TelegramPost], emoji: str) ->
         else:
             entry_block = format_entry(i, title, summary_text, url)
         block_len = len(entry_block)
-        if total_length + block_len > 4096:
+        if total_length + block_len > TELEGRAM_MESSAGE_LIMIT:
             logger.warning(f"✂️ Дайджест '{category}' досяг ліміту символів. Зупинка на {i} постах.")
             break
         result.append(entry_block)

--- a/config.py
+++ b/config.py
@@ -23,6 +23,9 @@ MAX_POSTS_PER_REQUEST = 10
 MIN_POST_LENGTH = 100
 MAX_POST_LENGTH = 3500
 
+# Telegram message hard limit
+TELEGRAM_MESSAGE_LIMIT = 4096
+
 SYSTEM_PROMPT = (
     "Ти — бот, що формує щоденні дайджести з Telegram-постів українською мовою. "
     "Твоє завдання — стиснути пост, зберігаючи ключову суть і настрій, у формат:\n"


### PR DESCRIPTION
## Summary
- add `TELEGRAM_MESSAGE_LIMIT` to `config.py`
- use new limit constant in formatter instead of hard coded value

## Testing
- `pip install -r requirements.txt`
- `mypy --config-file mypy.ini .`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68404d2da53c8324bef3478bb0b7c446