### PR TITLE
Filter ads in sanitizer

### DIFF
--- a/digest/digest_thread.py
+++ b/digest/digest_thread.py
@@ -47,7 +47,9 @@ class DigestThread:
 
             logger.info(f"🧾 '{self.category}': {len(final_posts)} нових, {len(posts) - len(final_posts)} відфільтровано")
             logger.info(f"✅ Нових постів для '{self.category}': {len(final_posts)}")
-            logger.info(f"🧹 Всього відфільтровано {len(posts) - len(final_posts)} постів у '{self.category}'")
+            logger.info(
+                f"🧹 Всього відфільтровано {len(posts) - len(final_posts)} постів у '{self.category}'"
+            )
 
             for ch, msg_id, length in too_short_posts:
                 logger.info(f"   ⛔ {ch}/{msg_id} — короткий ({length} симв.)")

--- a/summarizer/sanitizer.py
+++ b/summarizer/sanitizer.py
@@ -9,6 +9,10 @@ def sanitize_post_text(text: str) -> str | None:
     if re.search(r"(?:\d[ -]*?){16}", text):
         return None
 
+    # Відфільтровуємо рекламні пости
+    if "#реклама" in text.lower():
+        return None
+
     text = unescape(text)                        # &amp; → &
     text = re.sub(r"<[^>]+>", "", text)          # Видалення HTML-тегів
     text = re.sub(r"http\S+", "", text)          # Видалення посилань


### PR DESCRIPTION
## Summary
- keep DigestThread filtering focused on length
- drop posts with card numbers or `#реклама` in `sanitize_post_text`

## Testing
- `python -m py_compile digest/digest_thread.py summarizer/sanitizer.py`
- `python -m mypy .`


------
https://chatgpt.com/codex/tasks/task_e_684066af2e448324b59f1372ee0bae17